### PR TITLE
Remove logback.xml from jar

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -77,3 +77,9 @@ libraryDependencies ++= Seq(
   "com.typesafe"                  % "config"                % "1.2.1",
   "org.scalatest"                 %% "scalatest"            % "2.2.2"     % "test"
 )
+
+mappings in(Compile, packageBin) ~= {
+  _.filterNot {
+    case (file, _) => file.getName == "logback.xml"
+  }
+}


### PR DESCRIPTION
If several logback configuration file are present in the classpath, there is no guarantee of which one will be applied.

In my case, including hipchat-scala conflicts with the play-framework logback file and yields:
```
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/.ivy2/cache/org.slf4j/slf4j-simple/jars/slf4j-simple-1.7.7.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/.ivy2/cache/ch.qos.logback/logback-classic/jars/logback-classic-1.1.1.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [org.slf4j.impl.SimpleLoggerFactory]

10:36:23,892 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Could NOT find resource [logback.groovy]
10:36:23,892 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Could NOT find resource [logback-test.xml]
10:36:23,892 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Found resource [logback.xml] at [jar:file:/.ivy2/cache/com.typesafe.play/play_2.11/jars/play_2.11-2.3.7.jar!/logback.xml]
10:36:23,892 |-WARN in ch.qos.logback.classic.LoggerContext[default] - Resource [logback.xml] occurs multiple times on the classpath.
10:36:23,893 |-WARN in ch.qos.logback.classic.LoggerContext[default] - Resource [logback.xml] occurs at [jar:file:/.ivy2/cache/com.imadethatcow/hipchat-scala_2.11/jars/hipchat-scala_2.11-0.1.jar!/logback.xml]
10:36:23,893 |-WARN in ch.qos.logback.classic.LoggerContext[default] - Resource [logback.xml] occurs at [jar:file:/.ivy2/cache/com.typesafe.play/play_2.11/jars/play_2.11-2.3.7.jar!/logback.xml]
```
The next play version will fix it: https://github.com/playframework/playframework/issues/3245.