### PR TITLE
Make all case classes seriazables

### DIFF
--- a/src/main/scala/com/imadethatcow/hipchat/common/caseclass/Auth.scala
+++ b/src/main/scala/com/imadethatcow/hipchat/common/caseclass/Auth.scala
@@ -11,7 +11,7 @@ case class AuthRequest(
   scope:         Option[String] = None,
   password:      Option[String] = None,
   refresh_token: Option[String] = None
-)
+) extends Serializable
 
 case class AuthResponse(
   access_token:  String,
@@ -21,7 +21,7 @@ case class AuthResponse(
   scope:         String,
   group_id:      String,
   refresh_token: Option[String] = None
-)
+) extends Serializable
 
 case class GetSessionResponse(
   scopes:       Seq[String],
@@ -30,7 +30,7 @@ case class GetSessionResponse(
   client:       AuthClient,
   owner:        Option[UsersItem],
   owner_type:   String
-)
+) extends Serializable
 
 case class AuthClient(
   room:            Option[RoomsItem],
@@ -38,4 +38,4 @@ case class AuthClient(
   allowed_scopes:  Seq[String],
   name:            Option[String],
   oauth_client_id: String
-)
+) extends Serializable

--- a/src/main/scala/com/imadethatcow/hipchat/common/caseclass/Emoticon.scala
+++ b/src/main/scala/com/imadethatcow/hipchat/common/caseclass/Emoticon.scala
@@ -15,4 +15,4 @@ case class EmoticonDetails(
   creator:    UsersItem,
   links:      EmoticonsItemLinks,
   url:        String
-)
+) extends Serializable

--- a/src/main/scala/com/imadethatcow/hipchat/common/caseclass/From.scala
+++ b/src/main/scala/com/imadethatcow/hipchat/common/caseclass/From.scala
@@ -1,4 +1,4 @@
 package com.imadethatcow.hipchat.common.caseclass
 
-case class From(id: Long, links: FromLinks, mention_name: String, name: String)
-case class FromLinks(self: String)
+case class From(id: Long, links: FromLinks, mention_name: String, name: String) extends Serializable
+case class FromLinks(self: String) extends Serializable

--- a/src/main/scala/com/imadethatcow/hipchat/common/caseclass/HCFile.scala
+++ b/src/main/scala/com/imadethatcow/hipchat/common/caseclass/HCFile.scala
@@ -1,3 +1,3 @@
 package com.imadethatcow.hipchat.common.caseclass
 
-case class HCFile(name: String, size: Long, url: String)
+case class HCFile(name: String, size: Long, url: String) extends Serializable

--- a/src/main/scala/com/imadethatcow/hipchat/common/caseclass/History.scala
+++ b/src/main/scala/com/imadethatcow/hipchat/common/caseclass/History.scala
@@ -1,8 +1,8 @@
 package com.imadethatcow.hipchat.common.caseclass
 
-case class HistoriesLinks(self: String, prev: String = "", next: String = "")
-case class HistoriesResponse(items: Seq[HistoryItem], startIndex: Long, maxResults: Long, links: HistoriesLinks)
+case class HistoriesLinks(self: String, prev: String = "", next: String = "") extends Serializable
+case class HistoriesResponse(items: Seq[HistoryItem], startIndex: Long, maxResults: Long, links: HistoriesLinks) extends Serializable
 // TODO look into Jackson's @JsonIgnoreProperties annotation
 // TODO kinda sucks that "from" seems to either return an object or a string :p
-case class HistoryItem(color: String, date: String, file: HCFile, from: Any, id: String, mentions: Seq[MentionItem], message: String, message_format: String)
-case class HistoryItemFromString(color: String, date: String, file: HCFile, from: String, id: String, mentions: Seq[MentionItem], message: String, message_format: String)
+case class HistoryItem(color: String, date: String, file: HCFile, from: Any, id: String, mentions: Seq[MentionItem], message: String, message_format: String) extends Serializable
+case class HistoryItemFromString(color: String, date: String, file: HCFile, from: String, id: String, mentions: Seq[MentionItem], message: String, message_format: String) extends Serializable

--- a/src/main/scala/com/imadethatcow/hipchat/common/caseclass/Mention.scala
+++ b/src/main/scala/com/imadethatcow/hipchat/common/caseclass/Mention.scala
@@ -1,3 +1,3 @@
 package com.imadethatcow.hipchat.common.caseclass
 
-case class Mention(id: Long, mention_name: String, name: String)
+case class Mention(id: Long, mention_name: String, name: String) extends Serializable

--- a/src/main/scala/com/imadethatcow/hipchat/common/caseclass/Mentions.scala
+++ b/src/main/scala/com/imadethatcow/hipchat/common/caseclass/Mentions.scala
@@ -1,4 +1,4 @@
 package com.imadethatcow.hipchat.common.caseclass
 
-case class MentionItem(id: Long, links: MentionLinks, mention_name: String, name: String)
-case class MentionLinks(self: String)
+case class MentionItem(id: Long, links: MentionLinks, mention_name: String, name: String) extends Serializable
+case class MentionLinks(self: String) extends Serializable

--- a/src/main/scala/com/imadethatcow/hipchat/common/caseclass/Photo.scala
+++ b/src/main/scala/com/imadethatcow/hipchat/common/caseclass/Photo.scala
@@ -1,3 +1,3 @@
 package com.imadethatcow.hipchat.common.caseclass
 
-case class Photo(photo: String)
+case class Photo(photo: String) extends Serializable

--- a/src/main/scala/com/imadethatcow/hipchat/common/caseclass/PrivateMessage.scala
+++ b/src/main/scala/com/imadethatcow/hipchat/common/caseclass/PrivateMessage.scala
@@ -1,3 +1,3 @@
 package com.imadethatcow.hipchat.common.caseclass
 
-case class PrivateMessage(message: String)
+case class PrivateMessage(message: String) extends Serializable

--- a/src/main/scala/com/imadethatcow/hipchat/common/caseclass/Room.scala
+++ b/src/main/scala/com/imadethatcow/hipchat/common/caseclass/Room.scala
@@ -1,16 +1,16 @@
 package com.imadethatcow.hipchat.common.caseclass
 
-case class Room(id: Long, name: String)
-case class RoomsItem(id: Long, links: RoomsItemLinks, name: String)
-case class RoomsItemLinks(self: String, webhooks: String, members: Option[String])
-case class RoomsLinks(self: String, prev: Option[String], next: Option[String])
-case class RoomsResponse(items: Seq[RoomsItem], startIndex: Long, maxResults: Long, links: RoomsLinks)
-case class RoomsCreateResponse(id: Long, links: RoomDetailsStatsLinks)
-case class RoomsCreateRequest(guest_access: Boolean, name: String, owner_user_id: Option[String], privacy: String)
-case class RoomDetailsStatsLinks(self: String)
-case class RoomDetailsStats(links: RoomDetailsStatsLinks)
-case class RoomDetailsLinks(self: String, webhooks: String, members: String)
-case class RoomDetailsParticipantsLinks(self: String)
+case class Room(id: Long, name: String) extends Serializable
+case class RoomsItem(id: Long, links: RoomsItemLinks, name: String) extends Serializable
+case class RoomsItemLinks(self: String, webhooks: String, members: Option[String]) extends Serializable
+case class RoomsLinks(self: String, prev: Option[String], next: Option[String]) extends Serializable
+case class RoomsResponse(items: Seq[RoomsItem], startIndex: Long, maxResults: Long, links: RoomsLinks) extends Serializable
+case class RoomsCreateResponse(id: Long, links: RoomDetailsStatsLinks) extends Serializable
+case class RoomsCreateRequest(guest_access: Boolean, name: String, owner_user_id: Option[String], privacy: String) extends Serializable
+case class RoomDetailsStatsLinks(self: String) extends Serializable
+case class RoomDetailsStats(links: RoomDetailsStatsLinks) extends Serializable
+case class RoomDetailsLinks(self: String, webhooks: String, members: String) extends Serializable
+case class RoomDetailsParticipantsLinks(self: String) extends Serializable
 case class RoomDetails(
   xmpp_jid:            String,
   statistics:          RoomDetailsStats,
@@ -26,9 +26,9 @@ case class RoomDetails(
   id:                  Long,
   guest_access_url:    String,
   last_active:         String
-)
+) extends Serializable
 
-case class Owner(id: Option[Any])
+case class Owner(id: Option[Any]) extends Serializable
 case class RoomUpdate(
   name:                String,
   privacy:             String,
@@ -36,6 +36,6 @@ case class RoomUpdate(
   is_guest_accessible: Boolean,
   topic:               String,
   owner:               Owner
-)
+) extends Serializable
 
-case class TopicRequest(topic: String)
+case class TopicRequest(topic: String) extends Serializable

--- a/src/main/scala/com/imadethatcow/hipchat/common/caseclass/RoomNotification.scala
+++ b/src/main/scala/com/imadethatcow/hipchat/common/caseclass/RoomNotification.scala
@@ -5,4 +5,4 @@ case class RoomNotification(
   message:        String,
   _notify:        Boolean,
   message_format: String
-)
+) extends Serializable

--- a/src/main/scala/com/imadethatcow/hipchat/common/caseclass/User.scala
+++ b/src/main/scala/com/imadethatcow/hipchat/common/caseclass/User.scala
@@ -1,7 +1,7 @@
 package com.imadethatcow.hipchat.common.caseclass
 
-case class User(mention_name: String, id: Long, name: String)
-case class UsersItem(mention_name: String, id: Long, links: UsersItemLinks, name: String)
-case class UsersItemLinks(self: String)
-case class UsersLinks(self: String, prev: String = "", next: String = "")
-case class UsersResponse(items: Seq[UsersItem], startIndex: Long, maxResults: Long, links: UsersLinks)
+case class User(mention_name: String, id: Long, name: String) extends Serializable
+case class UsersItem(mention_name: String, id: Long, links: UsersItemLinks, name: String) extends Serializable
+case class UsersItemLinks(self: String) extends Serializable
+case class UsersLinks(self: String, prev: String = "", next: String = "") extends Serializable
+case class UsersResponse(items: Seq[UsersItem], startIndex: Long, maxResults: Long, links: UsersLinks) extends Serializable

--- a/src/main/scala/com/imadethatcow/hipchat/common/caseclass/Webhook.scala
+++ b/src/main/scala/com/imadethatcow/hipchat/common/caseclass/Webhook.scala
@@ -1,38 +1,38 @@
 package com.imadethatcow.hipchat.common.caseclass
 
-case class Webhook(room: Option[RoomsItem], url: String, pattern: Option[String], event: String, name: String, id: Long, creator: Option[UsersItem])
-case class WebhookSimple(url: String, pattern: Option[String], event: String, name: String, id: Long)
+case class Webhook(room: Option[RoomsItem], url: String, pattern: Option[String], event: String, name: String, id: Long, creator: Option[UsersItem]) extends Serializable
+case class WebhookSimple(url: String, pattern: Option[String], event: String, name: String, id: Long) extends Serializable
 
-case class WebhookCreateRequest(url: String, event: String, pattern: Option[String] = None, name: Option[String] = None)
-case class WebhookItemLinks(self: String)
-case class WebhookCreateResponse(id: Long, links: WebhookItemLinks)
+case class WebhookCreateRequest(url: String, event: String, pattern: Option[String] = None, name: Option[String] = None) extends Serializable
+case class WebhookItemLinks(self: String) extends Serializable
+case class WebhookCreateResponse(id: Long, links: WebhookItemLinks) extends Serializable
 
-case class WebhookGetRequest(room_id_or_name: String, webhook_id: Long)
-case class WebhookGetItem(room: Option[RoomsItem], links: WebhookItemLinks, creator: Option[UsersItem], url: String, pattern: Option[String], created: String, event: String, name: String, id: Long)
+case class WebhookGetRequest(room_id_or_name: String, webhook_id: Long) extends Serializable
+case class WebhookGetItem(room: Option[RoomsItem], links: WebhookItemLinks, creator: Option[UsersItem], url: String, pattern: Option[String], created: String, event: String, name: String, id: Long) extends Serializable
 
-case class WebhookGetSimpleItem(links: WebhookItemLinks, url: String, pattern: Option[String], event: String, name: String, id: Long)
-case class WebhookItemsLinks(self: String, prev: String, next: String)
-case class WebhookGetItems(items: Seq[WebhookGetSimpleItem], startIndex: Long, maxResults: Long, links: WebhookItemsLinks)
+case class WebhookGetSimpleItem(links: WebhookItemLinks, url: String, pattern: Option[String], event: String, name: String, id: Long) extends Serializable
+case class WebhookItemsLinks(self: String, prev: String, next: String) extends Serializable
+case class WebhookGetItems(items: Seq[WebhookGetSimpleItem], startIndex: Long, maxResults: Long, links: WebhookItemsLinks) extends Serializable
 
 // The following are all for webhook callbacks, starting with the common classes
-case class WebhookRoomLinks(members: Option[String], self: String, webhooks: String)
-case class WebhookRoom(id: Long, links: WebhookRoomLinks, name: String)
-case class WebhookSenderLinks(self: String)
-case class WebhookSender(id: Long, links: WebhookSenderLinks, mention_name: String, name: String)
+case class WebhookRoomLinks(members: Option[String], self: String, webhooks: String) extends Serializable
+case class WebhookRoom(id: Long, links: WebhookRoomLinks, name: String) extends Serializable
+case class WebhookSenderLinks(self: String) extends Serializable
+case class WebhookSender(id: Long, links: WebhookSenderLinks, mention_name: String, name: String) extends Serializable
 
-case class WebhookRoomEnterItem(room: WebhookRoom, sender: WebhookSender)
-case class WebhookRoomEnter(event: String, item: WebhookRoomEnterItem, oauth_client_id: Option[String], webhook_id: Long)
+case class WebhookRoomEnterItem(room: WebhookRoom, sender: WebhookSender) extends Serializable
+case class WebhookRoomEnter(event: String, item: WebhookRoomEnterItem, oauth_client_id: Option[String], webhook_id: Long) extends Serializable
 
-case class WebhookRoomExitItem(room: WebhookRoom, sender: WebhookSender)
-case class WebhookRoomExit(event: String, item: WebhookRoomExitItem, oauth_client_id: Option[String], webhook_id: Long)
+case class WebhookRoomExitItem(room: WebhookRoom, sender: WebhookSender) extends Serializable
+case class WebhookRoomExit(event: String, item: WebhookRoomExitItem, oauth_client_id: Option[String], webhook_id: Long) extends Serializable
 
-case class WebhookMessage(date: String, file: Option[HCFile], from: From, id: String, mentions: Option[Seq[MentionItem]], message: String)
-case class WebhookRoomMessageItem(message: WebhookMessage, room: Option[RoomsItem])
-case class WebhookRoomMessage(event: String, item: WebhookRoomMessageItem, oauth_client_id: Option[String], webhook_id: Long)
+case class WebhookMessage(date: String, file: Option[HCFile], from: From, id: String, mentions: Option[Seq[MentionItem]], message: String) extends Serializable
+case class WebhookRoomMessageItem(message: WebhookMessage, room: Option[RoomsItem]) extends Serializable
+case class WebhookRoomMessage(event: String, item: WebhookRoomMessageItem, oauth_client_id: Option[String], webhook_id: Long) extends Serializable
 
-case class WebhookRoomNotificationMessage(color: Option[String], date: String, from: Option[String], id: Long, mentions: Seq[Mention], message: String, message_format: String)
-case class WebhookRoomNotificationItem(message: WebhookRoomNotificationMessage, room: WebhookRoom)
-case class WebhookRoomNotification(event: String, item: WebhookRoomNotificationItem, oauth_client_id: Option[String], webhook_id: String)
+case class WebhookRoomNotificationMessage(color: Option[String], date: String, from: Option[String], id: Long, mentions: Seq[Mention], message: String, message_format: String) extends Serializable
+case class WebhookRoomNotificationItem(message: WebhookRoomNotificationMessage, room: WebhookRoom) extends Serializable
+case class WebhookRoomNotification(event: String, item: WebhookRoomNotificationItem, oauth_client_id: Option[String], webhook_id: String) extends Serializable
 
-case class WebhookRoomTopicChangeItem(room: WebhookRoom, sender: WebhookSender, topic: String)
-case class WebhookRoomTopicChange(event: String, item: WebhookRoomTopicChangeItem, oauth_client_id: Option[String], webhook_id: String)
+case class WebhookRoomTopicChangeItem(room: WebhookRoom, sender: WebhookSender, topic: String) extends Serializable
+case class WebhookRoomTopicChange(event: String, item: WebhookRoomTopicChangeItem, oauth_client_id: Option[String], webhook_id: String) extends Serializable

--- a/src/main/scala/com/imadethatcow/hipchat/common/enums/AuthGrantType.scala
+++ b/src/main/scala/com/imadethatcow/hipchat/common/enums/AuthGrantType.scala
@@ -1,6 +1,6 @@
 package com.imadethatcow.hipchat.common.enums
 
-object AuthGrantType extends Enumeration {
+object AuthGrantType extends Enumeration with Serializable {
   type AuthGrantType = Value
   val authorization_code, refresh_token, password, client_credentials, personal, room_notification = Value
 }

--- a/src/main/scala/com/imadethatcow/hipchat/common/enums/Color.scala
+++ b/src/main/scala/com/imadethatcow/hipchat/common/enums/Color.scala
@@ -1,6 +1,6 @@
 package com.imadethatcow.hipchat.common.enums
 
-object Color extends Enumeration {
+object Color extends Enumeration with Serializable {
   type Color = Value
   val yellow, red, green, purple, gray, random = Value
 }

--- a/src/main/scala/com/imadethatcow/hipchat/common/enums/EmoticonType.scala
+++ b/src/main/scala/com/imadethatcow/hipchat/common/enums/EmoticonType.scala
@@ -1,6 +1,6 @@
 package com.imadethatcow.hipchat.common.enums
 
-object EmoticonType extends Enumeration {
+object EmoticonType extends Enumeration with Serializable {
   type EmoticonType = Value
   val global, group, all = Value
 }

--- a/src/main/scala/com/imadethatcow/hipchat/common/enums/Event.scala
+++ b/src/main/scala/com/imadethatcow/hipchat/common/enums/Event.scala
@@ -1,6 +1,6 @@
 package com.imadethatcow.hipchat.common.enums
 
-object Event extends Enumeration {
+object Event extends Enumeration with Serializable {
   type Event = Value
   val room_message, room_notification, room_exit, room_enter, room_topic_change = Value
 }

--- a/src/main/scala/com/imadethatcow/hipchat/common/enums/MessageFormat.scala
+++ b/src/main/scala/com/imadethatcow/hipchat/common/enums/MessageFormat.scala
@@ -1,6 +1,6 @@
 package com.imadethatcow.hipchat.common.enums
 
-object MessageFormat extends Enumeration {
+object MessageFormat extends Enumeration with Serializable {
   type MessageFormat = Value
   val html, text = Value
 }

--- a/src/main/scala/com/imadethatcow/hipchat/common/enums/OwnerType.scala
+++ b/src/main/scala/com/imadethatcow/hipchat/common/enums/OwnerType.scala
@@ -1,6 +1,6 @@
 package com.imadethatcow.hipchat.common.enums
 
-object OwnerType extends Enumeration {
+object OwnerType extends Enumeration with Serializable {
   type OwnerType = Value
   val client, user = Value
 }

--- a/src/main/scala/com/imadethatcow/hipchat/common/enums/Privacy.scala
+++ b/src/main/scala/com/imadethatcow/hipchat/common/enums/Privacy.scala
@@ -1,6 +1,6 @@
 package com.imadethatcow.hipchat.common.enums
 
-object Privacy extends Enumeration {
+object Privacy extends Enumeration with Serializable {
   type Privacy = Value
   val public, `private` = Value
 }

--- a/src/main/scala/com/imadethatcow/hipchat/common/enums/Scope.scala
+++ b/src/main/scala/com/imadethatcow/hipchat/common/enums/Scope.scala
@@ -1,6 +1,6 @@
 package com.imadethatcow.hipchat.common.enums
 
-object Scope extends Enumeration {
+object Scope extends Enumeration with Serializable {
   type Scope = Value
   val send_notification, send_message, admin_room, view_group, admin_group, manage_rooms = Value
 }

--- a/src/main/scala/com/imadethatcow/hipchat/common/enums/WebhookEvent.scala
+++ b/src/main/scala/com/imadethatcow/hipchat/common/enums/WebhookEvent.scala
@@ -1,6 +1,6 @@
 package com.imadethatcow.hipchat.common.enums
 
-object WebhookEvent extends Enumeration {
+object WebhookEvent extends Enumeration with Serializable {
   type WebhookEvent = Value
   val room_message, room_notification, room_exit, room_enter, room_topic_change = Value
 }


### PR DESCRIPTION
So, I've working with spark recently connecting with Hipchat and needed a good library. The thing is that all the model beans (in this case all are case classes) needs to be serializables. So I added the Serializable inheritance to each one of them.