### PR TITLE
Allow to pass custom API base url

### DIFF
--- a/src/main/scala/com/imadethatcow/hipchat/Emoticons.scala
+++ b/src/main/scala/com/imadethatcow/hipchat/Emoticons.scala
@@ -5,13 +5,18 @@ import com.imadethatcow.hipchat.common.Logging
 import com.imadethatcow.hipchat.common.caseclass.{EmoticonDetails, Emoticon, EmoticonsResponse}
 import scala.concurrent.{ExecutionContext, Future}
 
-class Emoticons(private[this] val apiToken: String)(implicit executor: ExecutionContext) extends Logging {
+class Emoticons(private[this] val apiToken: String, private[this] val baseUrlOpt: Option[String] = None)(implicit executor: ExecutionContext) extends Logging {
+
+  private val baseUrl = reqFromBaseUrl(baseUrlOpt)
+  private val url = (baseUrl / "emoticon").GET
+  private def url(emoticonIdOrName: String) = (baseUrl / "emoticon" / emoticonIdOrName).GET
+
   def getAll(
     startIndex: Option[Long]    = None,
     maxResults: Option[Long]    = None,
     `type`:     Option[Boolean] = None
   ): Future[Seq[Emoticon]] = {
-    var req = addToken(Emoticons.url, apiToken)
+    var req = addToken(url, apiToken)
     for (si <- startIndex) req = req.addQueryParameter("start-index", si.toString)
     for (mr <- maxResults) req = req.addQueryParameter("max-results", mr.toString)
     for (t <- `type`) req = req.addQueryParameter("type", t.toString)
@@ -25,12 +30,7 @@ class Emoticons(private[this] val apiToken: String)(implicit executor: Execution
   }
 
   def get(emoticonIdOrKey: String): Future[EmoticonDetails] = {
-    val req = addToken(Emoticons.url(emoticonIdOrKey), apiToken)
+    val req = addToken(url(emoticonIdOrKey), apiToken)
     resolveAndDeserialize[EmoticonDetails](req)
   }
-}
-
-object Emoticons {
-  private val url = (apiUrl / "emoticon").GET
-  private def url(emoticonIdOrName: String) = (apiUrl / "emoticon" / emoticonIdOrName).GET
 }

--- a/src/main/scala/com/imadethatcow/hipchat/common/Common.scala
+++ b/src/main/scala/com/imadethatcow/hipchat/common/Common.scala
@@ -45,6 +45,10 @@ object Common extends Logging with Config {
     }
   }
 
+  def reqFromBaseUrl(baseUrlOpt: Option[String]): Req = {
+    baseUrlOpt.map(dispatch.url).getOrElse(apiUrl)
+  }
+
   @inline def resolveBoolRequest(req: Req, expectedResponseCode: Int = defaultResponseCode)(implicit executor: ExecutionContext): Future[Boolean] =
     resolveRequest(req, expectedResponseCode) map { _ => true } recover { case _: Exception => false }
 

--- a/src/main/scala/com/imadethatcow/hipchat/rooms/ViewHistory.scala
+++ b/src/main/scala/com/imadethatcow/hipchat/rooms/ViewHistory.scala
@@ -6,7 +6,10 @@ import com.imadethatcow.hipchat.common.caseclass.{HistoriesResponse, HistoryItem
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class ViewHistory(private[this] val apiToken: String)(implicit executor: ExecutionContext) extends Logging {
+class ViewHistory(private[this] val apiToken: String, private[this] val baseUrlOpt: Option[String] = None)(implicit executor: ExecutionContext) extends Logging {
+
+  private def url(roomIdOrName: String) = (reqFromBaseUrl(baseUrlOpt) / "room" / roomIdOrName / "history").GET
+
   def roomHistory(
     roomIdOrName: String,
     date:         Option[Any]     = None, // Must be either "recent" or conform to ISO-8601, use joda for the latter
@@ -15,7 +18,7 @@ class ViewHistory(private[this] val apiToken: String)(implicit executor: Executi
     maxResults:   Option[Long]    = None,
     reverse:      Option[Boolean] = None
   ): Future[Seq[HistoryItem]] = {
-    var req = addToken(ViewHistory.url(roomIdOrName), apiToken)
+    var req = addToken(url(roomIdOrName), apiToken)
     for (d <- date) req = req.addQueryParameter("date", d.toString)
     for (tz <- timezone) req = req.addQueryParameter("timezone", tz)
     for (si <- startIndex) req = req.addQueryParameter("start-index", si.toString)
@@ -26,8 +29,4 @@ class ViewHistory(private[this] val apiToken: String)(implicit executor: Executi
       response => response.items
     }
   }
-}
-
-object ViewHistory {
-  private def url(roomIdOrName: String) = (apiUrl / "room" / roomIdOrName / "history").GET
 }

--- a/src/main/scala/com/imadethatcow/hipchat/users/Photos.scala
+++ b/src/main/scala/com/imadethatcow/hipchat/users/Photos.scala
@@ -5,24 +5,22 @@ import Common._
 import com.imadethatcow.hipchat.common.caseclass.Photo
 import scala.concurrent.{ExecutionContext, Future}
 
-class Photos(private[this] val apiToken: String)(implicit executor: ExecutionContext) {
+class Photos(private[this] val apiToken: String, private[this] val baseUrlOpt: Option[String] = None)(implicit executor: ExecutionContext) {
+
+  private def url(idOrEmail: String) = reqFromBaseUrl(baseUrlOpt) / "user" / idOrEmail / "photo"
+  private def urlPut(idOrEmail: String) = url(idOrEmail).PUT
+  private def urlDelete(idOrEmail: String) = url(idOrEmail).DELETE
+
   def update(idOrEmail: String, encodedPhoto: String): Future[Boolean] = {
-    val req = addToken(Photos.urlPut(idOrEmail), apiToken)
+    val req = addToken(urlPut(idOrEmail), apiToken)
       .setBody(readMapper.writeValueAsString(Photo(encodedPhoto)))
       .setHeader("Content-Type", "application/json")
 
     resolveBoolRequest(req, 204)
   }
   def delete(idOrEmail: String): Future[Boolean] = {
-    val req = addToken(Photos.urlDelete(idOrEmail), apiToken)
+    val req = addToken(urlDelete(idOrEmail), apiToken)
 
     resolveBoolRequest(req, 204)
   }
-}
-
-object Photos {
-  private def url(idOrEmail: String) = apiUrl / "user" / idOrEmail / "photo"
-
-  def urlPut(idOrEmail: String) = url(idOrEmail).PUT
-  def urlDelete(idOrEmail: String) = url(idOrEmail).DELETE
 }

--- a/src/main/scala/com/imadethatcow/hipchat/users/PrivateMessenger.scala
+++ b/src/main/scala/com/imadethatcow/hipchat/users/PrivateMessenger.scala
@@ -5,16 +5,15 @@ import Common._
 import com.imadethatcow.hipchat.common.caseclass.PrivateMessage
 import scala.concurrent.{ExecutionContext, Future}
 
-class PrivateMessenger(private[this] val apiToken: String)(implicit executor: ExecutionContext) extends Logging {
+class PrivateMessenger(private[this] val apiToken: String, private[this] val baseUrlOpt: Option[String] = None)(implicit executor: ExecutionContext) extends Logging {
+
+  private def url(idOrEmail: String) = (reqFromBaseUrl(baseUrlOpt) / "user" / idOrEmail / "message").POST
+
   def sendMessage(idOrEmail: String, message: String): Future[Boolean] = {
-    val req = addToken(PrivateMessenger.url(idOrEmail), apiToken)
+    val req = addToken(url(idOrEmail), apiToken)
       .setBody(readMapper.writeValueAsString(PrivateMessage(message)))
       .setHeader("Content-Type", "application/json")
 
     resolveBoolRequest(req, 204)
   }
-}
-
-object PrivateMessenger {
-  private def url(idOrEmail: String) = (apiUrl / "user" / idOrEmail / "message").POST
 }

--- a/src/main/scala/com/imadethatcow/hipchat/users/Users.scala
+++ b/src/main/scala/com/imadethatcow/hipchat/users/Users.scala
@@ -5,14 +5,17 @@ import com.imadethatcow.hipchat.common.Logging
 import com.imadethatcow.hipchat.common.caseclass.{User, UsersResponse}
 import scala.concurrent.{ExecutionContext, Future}
 
-class Users(private[this] val apiToken: String)(implicit executor: ExecutionContext) extends Logging {
+class Users(private[this] val apiToken: String, private[this] val baseUrlOpt: Option[String] = None)(implicit executor: ExecutionContext) extends Logging {
+
+  private val url = (reqFromBaseUrl(baseUrlOpt) / "user").GET
+
   def getAll(
     startIndex:     Option[Long]    = None,
     maxResults:     Option[Long]    = None,
     includeGuests:  Option[Boolean] = None,
     includeDeleted: Option[Boolean] = None
   ): Future[Seq[User]] = {
-    var req = addToken(Users.url, apiToken)
+    var req = addToken(url, apiToken)
     for (si <- startIndex) req = req.addQueryParameter("start-index", si.toString)
     for (mr <- maxResults) req = req.addQueryParameter("max-results", mr.toString)
     for (ig <- includeGuests) req = req.addQueryParameter("include-guests", ig.toString)
@@ -26,8 +29,3 @@ class Users(private[this] val apiToken: String)(implicit executor: ExecutionCont
     }
   }
 }
-
-object Users {
-  val url = (apiUrl / "user").GET
-}
-


### PR DESCRIPTION
While the previous lib version allowed to use custom url by using a
config file, there was no easy way to use the lib to communicate with
several hipchat instances from the same application.
This solution allows to pass the base url as an optional param to
the classes doing the communication

Close #22 